### PR TITLE
Fix: Center align contact section heading text

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -145,7 +145,7 @@ const Contact = ({ email, social_handle, about }: ContactProps) => {
       </AnimatePresence>
       <span className="blob size-1/2 absolute top-20 right-0 blur-[100px] -z-10" />
       <div className="p-4 md:p-8 md:px-16">
-        <SectionHeading className="">
+        <SectionHeading className="text-center">
           <SlideIn className="text-white/40">Interested in talking,</SlideIn>{" "}
           <br /> <SlideIn>let&apos;s do it.</SlideIn>
         </SectionHeading>


### PR DESCRIPTION
## Summary

This PR fixes the alignment issue with the contact section heading "Interested in talking, let's do it." to ensure it's properly centered.

## Problem

After removing the Spline 3D elements in the previous PR, the contact section heading was left-aligned instead of being centered, which didn't match the overall centered layout of the contact form.

## Solution

Added `text-center` class to the `SectionHeading` component in the contact section to center-align the heading text.

## Changes Made

- **Contact Component** (`src/components/Contact.tsx`):
  - Added `text-center` class to `SectionHeading` component
  - This centers the "Interested in talking, let's do it." heading

## Before vs After

**Before**: Heading was left-aligned  
**After**: Heading is properly centered, matching the form layout

## Testing

- ✅ Build passes successfully
- ✅ No ESLint errors or warnings
- ✅ Heading is now properly centered
- ✅ All other functionality preserved

This is a small but important UI improvement that ensures consistent alignment throughout the contact section.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author